### PR TITLE
release-20.2: sql: fix CREATE STATISTICS for partial indexes

### DIFF
--- a/docs/codelabs/00-sql-function.md
+++ b/docs/codelabs/00-sql-function.md
@@ -7,7 +7,7 @@ tests.
 
 ## Getting Started
 
-Before we get started, you need to download the CockroachDB source code and
+Before we get started, download the CockroachDB source code and
 ensure you have all of the prerequisites needed for development. See
 [CONTRIBUTING.md] doc for details.
 


### PR DESCRIPTION
This commit fixes a bug that caused errors when creating stats for a
table with a partial index predicate containing references to
inverted-type columns, like JSON and ARRAY.

Fixes #

Release note (bug fix): The `CREATE STATISTICS` command no longer fails
when creating statistics on a table with a partial index predicate
containing references to an inverted-type column, such as `JSON`,
`ARRAY`, `GEOMETRY`, or `GEOGRAPHY`. This bug was present since partial
indexes were introduced in version 20.2.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yzdocs/cockroach/5)
<!-- Reviewable:end -->
